### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -89,7 +89,7 @@ class JupiterOneClient:
         if variables:
             data.update(variables=variables)
 
-        response = requests.post(self.query_endpoint, headers=self.headers, json=data)
+        response = requests.post(self.query_endpoint, headers=self.headers, json=data, timeout=60)
 
         # It is still unclear if all responses will have a status
         # code of 200 or if 429 will eventually be used to 


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Fjupiterone-api-client-python%7C73fe07e84faf89262f0f39609ffa5679838b4116)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->