### PR TITLE
Tests Refresh

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -3,6 +3,7 @@
 # see https://github.com/PyCQA/pylint/issues/409
 
 import json
+from warnings import warn
 from typing import Dict, List
 
 import requests
@@ -50,11 +51,11 @@ class JupiterOneClient:
         self.account = account
         self.token = token
         self.url = url
-        self.query_endpoint = self.url + "/graphql"
+        self.query_endpoint = self.url
         self.rules_endpoint = self.url + "/rules/graphql"
         self.headers = {
             "Authorization": "Bearer {}".format(self.token),
-            "Jupiterone-Account": self.account,
+            "JupiterOne-Account": self.account,
         }
 
     @property
@@ -124,7 +125,7 @@ class JupiterOneClient:
             raise JupiterOneApiRetryError("JupiterOne API rate limit exceeded.")
 
         elif response.status_code in [504]:
-            raise JupiterOneApiRetryError("Bad Gateway error. Check network route and try again.")
+            raise JupiterOneApiRetryError("Gateway Timeout.")
 
         elif response.status_code in [500]:
             raise JupiterOneApiError("JupiterOne API internal server error.")

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ from setuptools import setup, find_packages
 
 install_reqs = [
     'requests',
-    'retrying',
-    'warnings'
+    'retrying'
 ]
 
 setup(name='jupiterone',

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = ..

--- a/tests/test_create_entity.py
+++ b/tests/test_create_entity.py
@@ -32,7 +32,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_create_relationship.py
+++ b/tests/test_create_relationship.py
@@ -36,7 +36,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_delete_entity.py
+++ b/tests/test_delete_entity.py
@@ -33,7 +33,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_delete_relationship.py
+++ b/tests/test_delete_relationship.py
@@ -36,7 +36,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -29,7 +29,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )


### PR DESCRIPTION
- Tweaking a value for the `client.py` URL, as I think it's causing 404 errors with the new API URL Endpoint.
- Re-adding the missing `warn` import statement (not sure if we still need the one line that uses `warn()`, but it's there none-the-less).
- Aligning headers value during authentication with what is shown in the docs.
- Updating test files to use the new API endpoint.
- Adding config for `pytest` to help locate the project code.
- Removing some unused tests.
- Updating some tests that are referencing old or wrong error codes.

On my local system `pytest` now passes all tests (though, it might be good to confirm they're all still good).