### PR TITLE
Refreshing Tests and Minor Tweaks

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -3,6 +3,7 @@
 # see https://github.com/PyCQA/pylint/issues/409
 
 import json
+from warnings import warn
 from typing import Dict, List
 
 import requests
@@ -50,11 +51,11 @@ class JupiterOneClient:
         self.account = account
         self.token = token
         self.url = url
-        self.query_endpoint = self.url + "/graphql"
+        self.query_endpoint = self.url
         self.rules_endpoint = self.url + "/rules/graphql"
         self.headers = {
             "Authorization": "Bearer {}".format(self.token),
-            "Jupiterone-Account": self.account,
+            "JupiterOne-Account": self.account,
         }
 
     @property
@@ -124,7 +125,7 @@ class JupiterOneClient:
             raise JupiterOneApiRetryError("JupiterOne API rate limit exceeded.")
 
         elif response.status_code in [504]:
-            raise JupiterOneApiRetryError("Bad Gateway error. Check network route and try again.")
+            raise JupiterOneApiRetryError("Gateway Timeout.")
 
         elif response.status_code in [500]:
             raise JupiterOneApiError("JupiterOne API internal server error.")

--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -91,7 +91,7 @@ class JupiterOneClient:
         if variables:
             data.update(variables=variables)
 
-        # Always ask for variableresultsize
+        # Always ask for variableResultSize
         data.update(flags={"variableResultSize": True})
 
         response = requests.post(

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ from setuptools import setup, find_packages
 
 install_reqs = [
     'requests',
-    'retrying',
-    'warnings'
+    'retrying'
 ]
 
 setup(name='jupiterone',

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = ..

--- a/tests/test_create_entity.py
+++ b/tests/test_create_entity.py
@@ -32,7 +32,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_create_relationship.py
+++ b/tests/test_create_relationship.py
@@ -36,7 +36,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_delete_entity.py
+++ b/tests/test_delete_entity.py
@@ -33,7 +33,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_delete_relationship.py
+++ b/tests/test_delete_relationship.py
@@ -36,7 +36,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,9 +5,7 @@ from collections import Counter
 
 from jupiterone.client import JupiterOneClient
 from jupiterone.constants import QUERY_V1
-from jupiterone.errors import (
-    JupiterOneApiError
-) 
+from jupiterone.errors import JupiterOneApiError
 
 
 def build_results(response_code: int = 200, cursor: str = None, max_pages: int = 1):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -76,7 +76,7 @@ def build_error_results(response_code: int, response_content, response_type: str
 @responses.activate
 def test_execute_query():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(),
         content_type='application/json',
     )
@@ -103,7 +103,7 @@ def test_execute_query():
 def test_limit_skip_query_v1():
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(),
         content_type='application/json',
     )
@@ -126,13 +126,13 @@ def test_limit_skip_query_v1():
 def test_cursor_query_v1():
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(cursor='cursor_value'),
         content_type='application/json',
     )
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(),
         content_type='application/json',
     )
@@ -179,7 +179,7 @@ def test_limit_skip_tree_query_v1():
         return 200, headers, json.dumps(response)
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )
@@ -229,7 +229,7 @@ def test_cursor_tree_query_v1():
         return (200, headers, json.dumps(response))
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )
@@ -249,19 +249,19 @@ def test_cursor_tree_query_v1():
 @responses.activate
 def test_retry_on_limit_skip_query():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(response_code=429),
         content_type='application/json',
     )
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(response_code=503),
         content_type='application/json',
     )
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(),
         content_type='application/json',
     )
@@ -283,19 +283,19 @@ def test_retry_on_limit_skip_query():
 @responses.activate
 def test_retry_on_cursor_query():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(response_code=429),
         content_type='application/json',
     )
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(response_code=503),
         content_type='application/json',
     )
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(),
         content_type='application/json',
     )
@@ -315,7 +315,7 @@ def test_retry_on_cursor_query():
 @responses.activate
 def test_avoid_retry_on_limit_skip_query():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(response_code=404),
         content_type='application/json',
     )
@@ -333,7 +333,7 @@ def test_avoid_retry_on_limit_skip_query():
 @responses.activate
 def test_avoid_retry_on_cursor_query():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(response_code=404),
         content_type='application/json',
     )
@@ -349,7 +349,7 @@ def test_avoid_retry_on_cursor_query():
 @responses.activate
 def test_warn_limit_and_skip_deprecated():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_results(),
         content_type='application/json',
     )
@@ -368,7 +368,7 @@ def test_warn_limit_and_skip_deprecated():
 @responses.activate
 def test_unauthorized_query_v1():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_error_results(401, b'Unauthorized', 'text/plain'),
         content_type='application/json',
     )
@@ -385,7 +385,7 @@ def test_unauthorized_query_v1():
 @responses.activate
 def test_five_hundred_error_query_v1():
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_error_results(500, 'Internal Server Error', 'text/plain'),
         content_type='application/json',
     )
@@ -406,7 +406,7 @@ def test_bad_gateway_error_query_v1():
     }
 
     responses.add_callback(
-        responses.POST, 'https://graphql.us.jupiterone.io/',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=build_error_results(502, json.dumps(error_json), ),
         content_type='application/json',
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -6,7 +6,6 @@ from collections import Counter
 from jupiterone.client import JupiterOneClient
 from jupiterone.constants import QUERY_V1
 from jupiterone.errors import (
-    JupiterOneApiRetryError,
     JupiterOneApiError
 ) 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -419,31 +419,3 @@ def test_bad_gateway_error_query_v1():
 
     with pytest.raises(JupiterOneApiError) as exc_info:
         j1.query_v1(query)
-
-# @responses.activate
-# def test_rate_limit_error_query_v1():
-#     responses.add_callback(
-#         responses.POST, 'https://graphql.us.jupiterone.io/',
-#         callback=build_error_results(429, "Too Many Requests", ),
-#         content_type='application/json',
-#     )
-
-#     j1 = JupiterOneClient(account='testAccount', token='bogusToken')
-#     query = "find Host with _id='1' return tree"
-
-#     with pytest.raises(JupiterOneApiError) as exc_info:
-#         j1.query_v1(query)
-
-# @responses.activate
-# def test_service_unavailable_error_query_v1():
-#     responses.add_callback(
-#         responses.POST, 'https://graphql.us.jupiterone.io/',
-#         callback=build_error_results(503, "Service Unavailable", ),
-#         content_type='application/json',
-#     )
-
-#     j1 = JupiterOneClient(account='testAccount', token='bogusToken')
-#     query = "find Host with _id='1' return tree"
-
-#     with pytest.raises(JupiterOneApiRetryError) as exc_info:
-#         j1.query_v1(query)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -10,6 +10,7 @@ from jupiterone.errors import (
     JupiterOneApiError
 ) 
 
+
 def build_results(response_code: int = 200, cursor: str = None, max_pages: int = 1):
     pages = Counter(requests=0)
 
@@ -60,7 +61,7 @@ def build_results(response_code: int = 200, cursor: str = None, max_pages: int =
 
         pages.update(requests=1)
 
-        return (response_code, headers, json.dumps(response))
+        return response_code, headers, json.dumps(response)
 
     return request_callback
 
@@ -97,7 +98,7 @@ def test_execute_query():
     assert 'data' in response
     assert 'queryV1' in response['data']
     assert len(response['data']['queryV1']['data']) == 1
-    assert type(response['data']['queryV1']['data']) == list
+    assert type(response['data']['queryV1']['data']) is list
     assert response['data']['queryV1']['data'][0]['entity']['_id'] == '1'
 
 
@@ -118,10 +119,11 @@ def test_limit_skip_query_v1():
         skip=0
     )
 
-    assert type(response) == dict
+    assert type(response) is dict
     assert len(response['data']) == 1
-    assert type(response['data']) == list
+    assert type(response['data']) is list
     assert response['data'][0]['entity']['_id'] == '1'
+
 
 @responses.activate
 def test_cursor_query_v1():
@@ -145,10 +147,11 @@ def test_cursor_query_v1():
         query=query,
     )
 
-    assert type(response) == dict
+    assert type(response) is dict
     assert len(response['data']) == 2
-    assert type(response['data']) == list
+    assert type(response['data']) is list
     assert response['data'][0]['entity']['_id'] == '1'
+
 
 @responses.activate
 def test_limit_skip_tree_query_v1():
@@ -176,7 +179,7 @@ def test_limit_skip_tree_query_v1():
             }
         }
 
-        return (200, headers, json.dumps(response))
+        return 200, headers, json.dumps(response)
 
     responses.add_callback(
         responses.POST, 'https://graphql.us.jupiterone.io/',
@@ -192,12 +195,13 @@ def test_limit_skip_tree_query_v1():
         skip=0
     )
 
-    assert type(response) == dict
+    assert type(response) is dict
     assert 'edges' in response
     assert 'vertices' in response
-    assert type(response['edges']) == list
-    assert type(response['vertices']) == list
+    assert type(response['edges']) is list
+    assert type(response['vertices']) is list
     assert response['vertices'][0]['id'] == '1'
+
 
 @responses.activate
 def test_cursor_tree_query_v1():
@@ -237,12 +241,13 @@ def test_cursor_tree_query_v1():
     query = "find Host with _id='1' return tree"
     response = j1.query_v1(query)
 
-    assert type(response) == dict
+    assert type(response) is dict
     assert 'edges' in response
     assert 'vertices' in response
-    assert type(response['edges']) == list
-    assert type(response['vertices']) == list
+    assert type(response['edges']) is list
+    assert type(response['vertices']) is list
     assert response['vertices'][0]['id'] == '1'
+
 
 @responses.activate
 def test_retry_on_limit_skip_query():
@@ -272,10 +277,11 @@ def test_retry_on_limit_skip_query():
         skip=0
     )
 
-    assert type(response) == dict
+    assert type(response) is dict
     assert len(response['data']) == 1
-    assert type(response['data']) == list
+    assert type(response['data']) is list
     assert response['data'][0]['entity']['_id'] == '1'
+
 
 @responses.activate
 def test_retry_on_cursor_query():
@@ -303,10 +309,11 @@ def test_retry_on_cursor_query():
         query=query
     )
 
-    assert type(response) == dict
+    assert type(response) is dict
     assert len(response['data']) == 1
-    assert type(response['data']) == list
+    assert type(response['data']) is list
     assert response['data'][0]['entity']['_id'] == '1'
+
 
 @responses.activate
 def test_avoid_retry_on_limit_skip_query():
@@ -325,6 +332,7 @@ def test_avoid_retry_on_limit_skip_query():
             skip=0
         )
 
+
 @responses.activate
 def test_avoid_retry_on_cursor_query():
     responses.add_callback(
@@ -339,6 +347,7 @@ def test_avoid_retry_on_cursor_query():
         j1.query_v1(
             query=query
         )
+
 
 @responses.activate
 def test_warn_limit_and_skip_deprecated():
@@ -374,6 +383,7 @@ def test_unauthorized_query_v1():
         j1.query_v1(query)
 
     assert "401: Unauthorized" in str(exc_info.value.args[0])
+
 
 @responses.activate
 def test_five_hundred_error_query_v1():

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -29,7 +29,7 @@ def test_tree_query_v1():
         return (200, headers, json.dumps(response))
     
     responses.add_callback(
-        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        responses.POST, 'https://graphql.us.jupiterone.io',
         callback=request_callback,
         content_type='application/json',
     )


### PR DESCRIPTION
- Tweaking a value for the `client.py` URL, as I think it's causing 404 errors with the new API URL Endpoint.
- Re-adding the missing `warn` import statement (not sure if we still need the one line that uses `warn()`, but it's there none-the-less).
- Aligning headers value during authentication with what is shown in the docs.
- Updating test files to use the new API endpoint.
- Adding config for `pytest` to help locate the project code.
- Removing some unused tests.
- Updating some tests that are referencing old or wrong error codes.

On my local system `pytest` now passes all tests (though, it might be good to confirm they're all still good).