### PR TITLE
fix: fix the notorious bearer token issue

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -53,7 +53,7 @@ class JupiterOneClient:
         self.account = account
         self.token = token
         self.url = url
-        self.query_endpoint = self.url
+        self.query_endpoint = self.url + "/graphql"
         self.rules_endpoint = self.url + "/rules/graphql"
         self.headers = {
             "Authorization": "Bearer {}".format(self.token),


### PR DESCRIPTION
Up to this point, this lib does not really work, every time one makes `query_v1` requests, it just breaks with the following error: 

```
jupiterone.errors.JupiterOneApiError: 403:'xxx' not a valid key=value pair (missing equal-sign) in Authorization header: 'Bearer xxx'.
```

After some discovery, it is actually this missing path that is causing the problem. Please update this so we can continue using lib>=1.0 

