### PR TITLE
Allowed 'start_sync_job' to use an 'api' source

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -542,9 +542,11 @@ class JupiterOneClient:
 
         data = {
                "source": source,
-               "integrationInstanceId": instance_id,
                "syncMode": sync_mode
-               }
+        }
+
+        if instance_id is not None:
+            data["integrationInstanceId"] = instance_id
 
         response = self._execute_syncapi_request(endpoint=endpoint, payload=data)
 


### PR DESCRIPTION
The sync API doesn't need an integration id when using an 'api' source.