### PR TITLE
Potential fix for code scanning alert no. 123: Unused import

### DIFF
--- a/tests/test_delete_entity.py
+++ b/tests/test_delete_entity.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 import responses
 
 from jupiterone.client import JupiterOneClient


### PR DESCRIPTION
Potential fix for [https://github.com/JupiterOne/jupiterone-api-client-python/security/code-scanning/123](https://github.com/JupiterOne/jupiterone-api-client-python/security/code-scanning/123)

Remove the unused `import pytest` statement from `tests/test_delete_entity.py`.

Best fix without changing behavior:
- In `tests/test_delete_entity.py`, delete line 2 (`import pytest`).
- Keep all other imports and test logic unchanged.

No additional methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
