### PR TITLE
Custom User-Agent header, Migrated all bare requests.post() to self.session.post(), Version bump to 2.3.0

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -68,6 +68,7 @@ class JupiterOneClient:
 
     # pylint: disable=too-many-instance-attributes
 
+    SDK_VERSION: str = "2.3.0"
     DEFAULT_URL: str = "https://graphql.us.jupiterone.io"
     SYNC_API_URL: str = "https://api.us.jupiterone.io"
 
@@ -77,6 +78,7 @@ class JupiterOneClient:
         token: Optional[str] = None,
         url: str = DEFAULT_URL,
         sync_url: str = SYNC_API_URL,
+        user_agent: Optional[str] = None,
     ) -> None:
         # Validate inputs
         self._validate_constructor_inputs(account, token, url, sync_url)
@@ -84,14 +86,20 @@ class JupiterOneClient:
         self.token: Optional[str] = token
         self.graphql_url: str = url
         self.sync_url: str = sync_url
+
+        base_ua = f"jupiterone-client-python/{self.SDK_VERSION}"
+        full_ua = f"{base_ua} {user_agent}" if user_agent else base_ua
+
         self.headers: Dict[str, str] = {
             "Authorization": "Bearer {}".format(self.token or ""),
             "JupiterOne-Account": self.account or "",
             "Content-Type": "application/json",
+            "User-Agent": full_ua,
         }
 
         # Initialize session with retry logic
         self.session: requests.Session = requests.Session()
+        self.session.headers["User-Agent"] = full_ua
         retries = Retry(
             total=5,
             backoff_factor=1,
@@ -1204,8 +1212,8 @@ class JupiterOneClient:
 
         data = {"query": LIST_RULE_INSTANCES, "flags": {"variableResultSize": True}}
 
-        r = requests.post(
-            url=self.graphql_url, headers=self.headers, json=data, verify=True
+        r = self.session.post(
+            url=self.graphql_url, headers=self.headers, json=data, timeout=60
         ).json()
         results.extend(r["data"]["listRuleInstances"]["questionInstances"])
 
@@ -1220,8 +1228,8 @@ class JupiterOneClient:
                 "flags": {"variableResultSize": True},
             }
 
-            r = requests.post(
-                url=self.graphql_url, headers=self.headers, json=data, verify=True
+            r = self.session.post(
+                url=self.graphql_url, headers=self.headers, json=data, timeout=60
             ).json()
             results.extend(r["data"]["listRuleInstances"]["questionInstances"])
 
@@ -1233,8 +1241,8 @@ class JupiterOneClient:
 
         data = {"query": LIST_RULE_INSTANCES, "flags": {"variableResultSize": True}}
 
-        r = requests.post(
-            url=self.graphql_url, headers=self.headers, json=data, verify=True
+        r = self.session.post(
+            url=self.graphql_url, headers=self.headers, json=data, timeout=60
         ).json()
         results.extend(r["data"]["listRuleInstances"]["questionInstances"])
 
@@ -1249,8 +1257,8 @@ class JupiterOneClient:
                 "flags": {"variableResultSize": True},
             }
 
-            r = requests.post(
-                url=self.graphql_url, headers=self.headers, json=data, verify=True
+            r = self.session.post(
+                url=self.graphql_url, headers=self.headers, json=data, timeout=60
             ).json()
             results.extend(r["data"]["listRuleInstances"]["questionInstances"])
 
@@ -1597,8 +1605,8 @@ class JupiterOneClient:
             }
         }
 
-        r = requests.post(
-            url=self.graphql_url, headers=self.headers, json=data, verify=True
+        r = self.session.post(
+            url=self.graphql_url, headers=self.headers, json=data, timeout=60
         ).json()
         results.extend(r["data"]["questions"]["questions"])
 
@@ -1619,8 +1627,8 @@ class JupiterOneClient:
                 },
             }
 
-            r = requests.post(
-                url=self.graphql_url, headers=self.headers, json=data, verify=True
+            r = self.session.post(
+                url=self.graphql_url, headers=self.headers, json=data, timeout=60
             ).json()
             results.extend(r["data"]["questions"]["questions"])
 
@@ -1925,8 +1933,8 @@ class JupiterOneClient:
 
         data = {"query": PARAMETER_LIST, "flags": {"variableResultSize": True}}
 
-        r = requests.post(
-            url=self.graphql_url, headers=self.headers, json=data, verify=True
+        r = self.session.post(
+            url=self.graphql_url, headers=self.headers, json=data, timeout=60
         ).json()
         results.extend(r["data"]["parameterList"]["items"])
 
@@ -1940,8 +1948,8 @@ class JupiterOneClient:
                 "flags": {"variableResultSize": True},
             }
 
-            r = requests.post(
-                url=self.graphql_url, headers=self.headers, json=data, verify=True
+            r = self.session.post(
+                url=self.graphql_url, headers=self.headers, json=data, timeout=60
             ).json()
             results.extend(r["data"]["parameterList"]["items"])
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_reqs = ["requests", "retrying"]
 
 setup(
     name="jupiterone",
-    version="2.2.0",
+    version="2.3.0",
     description="A Python client for the JupiterOne API",
     license="MIT License",
     author="JupiterOne",

--- a/tests/test_alert_rule_methods.py
+++ b/tests/test_alert_rule_methods.py
@@ -15,7 +15,7 @@ class TestAlertRuleMethods:
         """Set up test fixtures"""
         self.client = JupiterOneClient(account="test-account", token="test-token")
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_alert_rules(self, mock_post):
         """Test list_alert_rules method"""
         # Mock first page response
@@ -55,7 +55,7 @@ class TestAlertRuleMethods:
         assert result[1]["id"] == "rule-2"
         assert mock_post.call_count == 2
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_get_alert_rule_details_found(self, mock_post):
         """Test get_alert_rule_details method - rule found"""
         # Mock response with the target rule
@@ -81,7 +81,7 @@ class TestAlertRuleMethods:
         assert result["id"] == "rule-1"
         assert result["name"] == "Test Rule"
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_get_alert_rule_details_not_found(self, mock_post):
         """Test get_alert_rule_details method - rule not found"""
         # Mock response without the target rule

--- a/tests/test_delete_entity.py
+++ b/tests/test_delete_entity.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 import responses
 
 from jupiterone.client import JupiterOneClient

--- a/tests/test_list_questions.py
+++ b/tests/test_list_questions.py
@@ -15,7 +15,7 @@ class TestListQuestions:
         """Set up test fixtures"""
         self.client = JupiterOneClient(account="test-account", token="test-token")
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_basic(self, mock_post):
         """Test basic questions listing with single page"""
         # Mock response for single page
@@ -101,7 +101,7 @@ class TestListQuestions:
         assert call_args[1]['json']['query'] == QUESTIONS
         assert call_args[1]['json']['flags']['variableResultSize'] is True
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_pagination(self, mock_post):
         """Test questions listing with multiple pages"""
         # Mock first page response
@@ -198,7 +198,7 @@ class TestListQuestions:
         assert second_call[1]['json']['variables']['cursor'] == "cursor-1"
         assert second_call[1]['json']['flags']['variableResultSize'] is True
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_empty_response(self, mock_post):
         """Test questions listing with empty response"""
         # Mock empty response
@@ -227,7 +227,7 @@ class TestListQuestions:
         # Verify API call
         mock_post.assert_called_once()
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_compliance_data(self, mock_post):
         """Test questions listing with compliance metadata"""
         # Mock response with compliance data
@@ -279,7 +279,7 @@ class TestListQuestions:
         assert compliance['requirements'] == ["2.1", "2.2", "2.3"]
         assert compliance['controls'] == ["Data Protection", "Network Security"]
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_variables(self, mock_post):
         """Test questions listing with variable definitions"""
         # Mock response with variables
@@ -341,7 +341,7 @@ class TestListQuestions:
         assert variables[1]['required'] is False
         assert variables[1]['default'] == "us-east-1"
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_polling_intervals(self, mock_post):
         """Test questions listing with different polling intervals"""
         # Mock response with various polling intervals
@@ -413,7 +413,7 @@ class TestListQuestions:
         assert result[1]['showTrend'] is True
         assert result[2]['showTrend'] is False
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_error_handling(self, mock_post):
         """Test questions listing with error handling"""
         # Mock error response
@@ -433,7 +433,7 @@ class TestListQuestions:
         with pytest.raises(Exception):
             self.client.list_questions()
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_malformed_response(self, mock_post):
         """Test questions listing with malformed response"""
         # Mock malformed response
@@ -466,7 +466,7 @@ class TestListQuestions:
         # Missing fields should be None or not present
         assert 'title' not in question or question['title'] is None
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_search_query(self, mock_post):
         """Test questions listing with search query parameter"""
         # Mock response for search query
@@ -512,7 +512,7 @@ class TestListQuestions:
         call_args = mock_post.call_args
         assert call_args[1]['json']['variables']['searchQuery'] == "security"
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_tags_filter(self, mock_post):
         """Test questions listing with tags filter parameter"""
         # Mock response for tags filter
@@ -563,7 +563,7 @@ class TestListQuestions:
         call_args = mock_post.call_args
         assert call_args[1]['json']['variables']['tags'] == ["cis", "aws"]
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_search_and_tags(self, mock_post):
         """Test questions listing with both search query and tags filter"""
         # Mock response for combined search and tags
@@ -620,7 +620,7 @@ class TestListQuestions:
         assert variables['searchQuery'] == "encryption"
         assert variables['tags'] == ["security", "compliance"]
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_with_pagination_and_filters(self, mock_post):
         """Test questions listing with filters and pagination"""
         # Mock first page response with filters
@@ -709,7 +709,7 @@ class TestListQuestions:
         assert second_variables['tags'] == ["security"]
         assert second_variables['cursor'] == "cursor-1"
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_no_parameters(self, mock_post):
         """Test questions listing with no parameters (default behavior)"""
         # Mock response for no parameters
@@ -753,7 +753,7 @@ class TestListQuestions:
         call_args = mock_post.call_args
         assert call_args[1]['json']['variables'] == {}
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_empty_search_results(self, mock_post):
         """Test questions listing with search that returns no results"""
         # Mock empty response for search
@@ -784,7 +784,7 @@ class TestListQuestions:
         call_args = mock_post.call_args
         assert call_args[1]['json']['variables']['searchQuery'] == "nonexistent"
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions_empty_tags_results(self, mock_post):
         """Test questions listing with tags filter that returns no results"""
         # Mock empty response for tags filter

--- a/tests/test_misc_methods.py
+++ b/tests/test_misc_methods.py
@@ -14,7 +14,7 @@ class TestMiscMethods:
         """Set up test fixtures"""
         self.client = JupiterOneClient(account="test-account", token="test-token")
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_questions(self, mock_post):
         """Test list_questions method"""
         # Mock first page response
@@ -91,7 +91,7 @@ class TestMiscMethods:
         assert result == mock_response
         mock_execute_query.assert_called_once()
 
-    @patch('jupiterone.client.requests.post')
+    @patch('requests.Session.post')
     def test_list_account_parameters(self, mock_post):
         """Test list_account_parameters method"""
         # Mock first page response


### PR DESCRIPTION
## Summary

Adds a custom `User-Agent` header to all HTTP requests made by the SDK client, enabling server-side tracking of customer usage. Also consolidates all HTTP calls through a single `requests.Session` for consistent retry behavior, connection pooling, and header propagation.

## Changes

### Custom User-Agent Header
- Added `SDK_VERSION` class constant (`2.3.0`) to `JupiterOneClient`
- Added optional `user_agent` parameter to `__init__` for caller-provided identifiers
- Constructs structured header: `jupiterone-client-python/2.3.0` (default) or `jupiterone-client-python/2.3.0 <custom-suffix>`
- Sets User-Agent on both `self.headers` and `self.session.headers` to cover all request paths

**Usage:**
```python
# Default
client = JupiterOneClient(account="...", token="...")
# User-Agent: jupiterone-client-python/2.3.0

# Custom suffix
client = JupiterOneClient(account="...", token="...", user_agent="acme-scanner/1.0")
# User-Agent: jupiterone-client-python/2.3.0 acme-scanner/1.0
```

### Session Migration
Migrated 8 bare `requests.post()` calls to `self.session.post()` across 4 methods:
- `list_alert_rules`
- `get_alert_rule_details`
- `list_questions`
- `list_account_parameters`

These methods were previously bypassing the session's retry logic (`Retry` with backoff on 429/502/503/504), connection pooling, and now the User-Agent header. All calls now include `timeout=60` for consistency.

### Version Bump
- `setup.py`: `2.2.0` → `2.3.0`
- `JupiterOneClient.SDK_VERSION`: `2.3.0`

### Test Updates
Updated mock targets in 3 test files from `@patch('jupiterone.client.requests.post')` to `@patch('requests.Session.post')` to match the migrated code:
- `tests/test_alert_rule_methods.py` (3 tests)
- `tests/test_list_questions.py` (15 tests)
- `tests/test_misc_methods.py` (2 tests)

## Test Plan
- [x] All 69 tests in affected files pass
- [x] No linter errors introduced
- [x] No bare `requests.post/get` calls remain in client.py
- [x] User-Agent set on both `self.headers` and `self.session.headers`